### PR TITLE
Fix list variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
 data "aws_iam_policy_document" "default" {
   statement {
-    actions = "${var.ssm_actions}"
+    actions = ["${var.ssm_actions}"]
 
-    resources = "${var.ssm_resources}"
+    resources = ["${var.ssm_resources}"]
   }
 
   statement {


### PR DESCRIPTION
## what
* Fix list variables
* Lists should be inclosed in `[]`

## why
When assigning values from top-level modules 
(e.g. `ssm_resources = ["${format("arn:aws:ssm:%s:%s:parameter/kops/*", module.identity.aws_region, module.identity.account_id)}"]`, 

throws the error:

```
Plan: 0 to add, 1 to change, 0 to destroy.


✅   (joany-staging-admin) chamber ➤  terraform plan
Acquiring state lock. This may take a few moments...
Releasing state lock. This may take a few moments...

Error: module.chamber_user.data.aws_iam_policy_document.default: statement.0.resources: 
should be a list
```
