### PR TITLE
Issue with race condition - kms key module failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,24 @@ We do not recommend creating IAM users this way for any other purpose.
 
 ## Usage
 
-```hcl
+```terraform
 module "chamber_user" {
-  source      = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=master"
-  namespace   = "cp"
-  stage       = "prod"
-  name        = "chamber"
-  kms_key_arn = "arn:aws:kms:us-west-2:253234095951:key/abfd558e-3275-4ece-84e5-b35abc46c243"
+  source        = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=master"
+  namespace     = "cp"
+  stage         = "prod"
+  name          = "chamber"
+  kms_key_alias = "alias/parameter_store_key"
+}
+
+module "kms_key" {
+  source                  = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=master"
+  namespace               = "cp"
+  stage                   = "prod"
+  name                    = "key"
+  description             = "KMS key for chamber"
+  deletion_window_in_days = 10
+  enable_key_rotation     = "true"
+  alias                   = "alias/parameter_store_key"
 }
 ```
 
@@ -26,7 +37,7 @@ module "chamber_user" {
 | `namespace`     |   ``    | Namespace (e.g. `cp` or `cloudposse`)                                                       |   Yes    |
 | `stage`         |   ``    | Stage (e.g. `prod`, `dev`, `staging`)                                                       |   Yes    |
 | `name`          |   ``    | Name  (e.g. `app`)                                                                          |   Yes    |
-| `kms_key_arn`   |   ``    | KMS key ARN used to decrypt secrets in Parameter Store                                      |   Yes    |
+| `kms_key_alias` |   `alias/parameter_store_key`    | KMS key alias used to decrypt secrets in Parameter Store                                    |   Yes    |
 | `attributes`    |  `[]`   | Additional attributes (e.g. `1`)                                                            |    No    |
 | `tags`          |  `{}`   | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                          |    No    |
 | `delimiter`     |   `-`   | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`                  |    No    |

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ data "aws_kms_alias" "kms_key" {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.5"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.2"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,8 @@ data "aws_iam_policy_document" "default" {
   }
 
   statement {
-    actions   = ["kms:Decrypt"]
+    actions = ["kms:Decrypt"]
+
     #resources = ["${var.kms_key_arn}"]
     resources = ["${data.aws_kms_alias.kms_key.arn}"]
     effect    = "Allow"
@@ -20,8 +21,9 @@ data "aws_iam_policy_document" "default" {
 }
 
 data "aws_kms_alias" "kms_key" {
-  name = "${var.kms_key_alias}" 
+  name = "${var.kms_key_alias}"
 }
+
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.5"
   namespace  = "${var.namespace}"
@@ -48,9 +50,9 @@ resource "aws_iam_access_key" "default" {
 }
 
 resource "aws_iam_user_policy" "default" {
-  count  = "${var.enabled == "true" ? 1 : 0}"
-  name   = "${module.label.id}"
-  user   = "${aws_iam_user.default.name}"
-  policy = "${data.aws_iam_policy_document.default.json}"
+  count      = "${var.enabled == "true" ? 1 : 0}"
+  name       = "${module.label.id}"
+  user       = "${aws_iam_user.default.name}"
+  policy     = "${data.aws_iam_policy_document.default.json}"
   depends_on = ["data.aws_kms_alias.kms_key", "data.aws_iam_policy_document.default"]
 }

--- a/main.tf
+++ b/main.tf
@@ -13,20 +13,44 @@ data "aws_iam_policy_document" "default" {
 
   statement {
     actions   = ["kms:Decrypt"]
-    resources = ["${var.kms_key_arn}"]
+    #resources = ["${var.kms_key_arn}"]
+    resources = ["${data.aws_kms_alias.kms_key.arn}"]
     effect    = "Allow"
   }
 }
 
-module "chamber_user" {
-  source        = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.2.2"
-  namespace     = "${var.namespace}"
-  stage         = "${var.stage}"
-  name          = "${var.name}"
-  attributes    = "${var.attributes}"
-  tags          = "${var.tags}"
-  enabled       = "${var.enabled}"
-  force_destroy = "${var.force_destroy}"
+data "aws_kms_alias" "kms_key" {
+  name = "${var.kms_key_alias}" 
+}
+module "label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.5"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  attributes = "${var.attributes}"
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+  enabled    = "${var.enabled}"
+}
+
+# Defines a user that should be able to write to you test bucket
+resource "aws_iam_user" "default" {
+  count         = "${var.enabled == "true" ? 1 : 0}"
+  name          = "${module.label.id}"
   path          = "${var.path}"
-  policy        = "${data.aws_iam_policy_document.default.json}"
+  force_destroy = "${var.force_destroy}"
+}
+
+# Generate API credentials
+resource "aws_iam_access_key" "default" {
+  count = "${var.enabled == "true" ? 1 : 0}"
+  user  = "${aws_iam_user.default.name}"
+}
+
+resource "aws_iam_user_policy" "default" {
+  count  = "${var.enabled == "true" ? 1 : 0}"
+  name   = "${module.label.id}"
+  user   = "${aws_iam_user.default.name}"
+  policy = "${data.aws_iam_policy_document.default.json}"
+  depends_on = ["data.aws_kms_alias.kms_key", "data.aws_iam_policy_document.default"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,6 @@
 #   description = "The secret access key. This will be written to the state file in plain-text"
 # }
 
-
 output "user_name" {
   value = "${join("", aws_iam_user.default.*.name)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,45 @@
+# output "user_name" {
+#   value       = "${module.chamber_user.user_name}"
+#   description = "Normalized IAM user name"
+# }
+
+# output "user_arn" {
+#   value       = "${module.chamber_user.user_arn}"
+#   description = "The ARN assigned by AWS for the user"
+# }
+
+# output "user_unique_id" {
+#   value       = "${module.chamber_user.user_unique_id}"
+#   description = "The user unique ID assigned by AWS"
+# }
+
+# output "access_key_id" {
+#   value       = "${module.chamber_user.access_key_id}"
+#   description = "The access key ID"
+# }
+
+# output "secret_access_key" {
+#   value       = "${module.chamber_user.secret_access_key}"
+#   description = "The secret access key. This will be written to the state file in plain-text"
+# }
+
+
 output "user_name" {
-  value       = "${module.chamber_user.user_name}"
-  description = "Normalized IAM user name"
+  value = "${join("", aws_iam_user.default.*.name)}"
 }
 
 output "user_arn" {
-  value       = "${module.chamber_user.user_arn}"
-  description = "The ARN assigned by AWS for the user"
+  value = "${join("", aws_iam_user.default.*.arn)}"
 }
 
 output "user_unique_id" {
-  value       = "${module.chamber_user.user_unique_id}"
-  description = "The user unique ID assigned by AWS"
+  value = "${join("", aws_iam_user.default.*.unique_id)}"
 }
 
 output "access_key_id" {
-  value       = "${module.chamber_user.access_key_id}"
-  description = "The access key ID"
+  value = "${join("", aws_iam_access_key.default.*.id)}"
 }
 
 output "secret_access_key" {
-  value       = "${module.chamber_user.secret_access_key}"
-  description = "The secret access key. This will be written to the state file in plain-text"
+  value = "${join("", aws_iam_access_key.default.*.secret)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "tags" {
 
 variable "kms_key_arn" {
   description = "ARN of the KMS key which will decrypt secret strings [DEPRECIATED: NO LONGER USED]"
-  default = ""
+  default     = ""
 }
 
 variable "kms_key_alias" {

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,13 @@ variable "tags" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of the KMS key which will decrypt secret strings"
+  description = "ARN of the KMS key which will decrypt secret strings [DEPRECIATED: NO LONGER USED]"
+  default = ""
+}
+
+variable "kms_key_alias" {
+  description = "Alias of the KMS key which will decrypt secret strings"
+  default     = "alias/parameter_store_key"
 }
 
 variable "ssm_actions" {


### PR DESCRIPTION
# What?

when using the two modules `terraform-aws-iam-chamber-user` and `terraform-aws-kms-key` at the same time like the example below the module would cause the `terraform-aws-iam-system-user` used by `terraform-aws-iam-chamber-user` to fail on calculating the **count** value of this section:
```hcl
resource "aws_iam_user_policy" "default" {
  count  = "${var.policy != "" ? 1 : 0}"
  name   = "${module.label.id}"
  user   = "${aws_iam_user.default.name}"
  policy = "${var.policy}"
}
```

So when it was used like this, it would cause this error when used like this:
```
Error: Error refreshing state: 1 error(s) occurred:

* module.chamber_user.module.chamber_user.aws_iam_user_policy.default: aws_iam_user_policy.default: value of 'count' cannot be computed
```
with this:
```hcl
module "chamber_user" {
  source      = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=master"
  namespace   = "${var.name}"
  stage       = "prod"
  name        = "chamber"
  kms_key_arn = "${module.kms_key.key_arn}"
}

module "kms_key" {
  source                  = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=master"
  namespace               = "${var.name}"
  stage                   = "prod"
  name                    = "key"
  description             = "KMS key for chamber"
  deletion_window_in_days = 10
  enable_key_rotation     = "true"
  alias                   = "alias/parameter_store_key"
}
```

Working now with this patch.
```hcl
module "chamber_user" {
  #source      = "git::https://github.com/cloudposse/terraform-aws-iam-chamber-user.git?ref=master"
  source = "../../../bitflight-terraform/terraform-aws-iam-chamber-user"
  namespace   = "${var.name}"
  stage       = "prod"
  name        = "chamber"
  kms_key_alias = "alias/parameter_store_key"
}

module "kms_key" {
  source                  = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=master"
  namespace               = "${var.name}"
  stage                   = "prod"
  name                    = "key"
  description             = "KMS key for chamber"
  deletion_window_in_days = 10
  enable_key_rotation     = "true"
  alias                   = "alias/parameter_store_key"
}
```