### PR TITLE
Fix ssm_actions and ssm_resources types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,8 @@ data "aws_iam_policy_document" "default" {
   }
 
   statement {
-    actions   = ["${var.ssm_actions}"]
-    resources = ["${var.ssm_resources}"]
+    actions   = var.ssm_actions
+    resources = var.ssm_resources
     effect    = "Allow"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -13,26 +13,26 @@ data "aws_iam_policy_document" "default" {
 
   statement {
     actions   = ["kms:Decrypt"]
-    resources = ["${var.kms_key_arn}"]
+    resources = [var.kms_key_arn]
     effect    = "Allow"
   }
 }
 
 module "chamber_user" {
   source        = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=tags/0.4.1"
-  namespace     = "${var.namespace}"
-  stage         = "${var.stage}"
-  name          = "${var.name}"
-  attributes    = "${var.attributes}"
-  tags          = "${var.tags}"
-  enabled       = "${var.enabled}"
-  force_destroy = "${var.force_destroy}"
-  path          = "${var.path}"
+  namespace     = var.namespace
+  stage         = var.stage
+  name          = var.name
+  attributes    = var.attributes
+  tags          = var.tags
+  enabled       = var.enabled
+  force_destroy = var.force_destroy
+  path          = var.path
 }
 
 resource "aws_iam_user_policy" "chamber_user" {
-  count  = "${var.enabled == "true" ? 1 : 0}"
-  name   = "${module.chamber_user.user_name}"
-  user   = "${module.chamber_user.user_name}"
-  policy = "${data.aws_iam_policy_document.default.json}"
+  count  = var.enabled == "true" ? 1 : 0
+  name   = module.chamber_user.user_name
+  user   = module.chamber_user.user_name
+  policy = data.aws_iam_policy_document.default.json
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,24 @@
 output "user_name" {
-  value       = "${module.chamber_user.user_name}"
+  value       = module.chamber_user.user_name
   description = "Normalized IAM user name"
 }
 
 output "user_arn" {
-  value       = "${module.chamber_user.user_arn}"
+  value       = module.chamber_user.user_arn
   description = "The ARN assigned by AWS for the user"
 }
 
 output "user_unique_id" {
-  value       = "${module.chamber_user.user_unique_id}"
+  value       = module.chamber_user.user_unique_id
   description = "The user unique ID assigned by AWS"
 }
 
 output "access_key_id" {
-  value       = "${module.chamber_user.access_key_id}"
+  value       = module.chamber_user.access_key_id
   description = "The access key ID"
 }
 
 output "secret_access_key" {
-  value       = "${module.chamber_user.secret_access_key}"
+  value       = module.chamber_user.secret_access_key
   description = "The secret access key. This will be written to the state file in plain-text"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,32 +1,32 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Application or solution name (e.g. `app`)"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
@@ -36,13 +36,13 @@ variable "kms_key_arn" {
 }
 
 variable "ssm_actions" {
-  type        = "list"
+  type        = list
   default     = ["ssm:GetParametersByPath", "ssm:GetParameters"]
   description = "Actions to allow in the policy"
 }
 
 variable "ssm_resources" {
-  type        = "list"
+  type        = list
   default     = ["*"]
   description = "Resources to apply the actions specified in the policy"
 }
@@ -53,6 +53,7 @@ variable "force_destroy" {
 }
 
 variable "path" {
+  type        = string
   default     = "/"
   description = "Path in which to create the user"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,7 @@ variable "tags" {
 }
 
 variable "kms_key_arn" {
+  type        = string
   description = "ARN of the KMS key which will decrypt secret strings"
 }
 
@@ -48,7 +49,8 @@ variable "ssm_resources" {
 }
 
 variable "force_destroy" {
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Destroy even if it has non-Terraform-managed IAM access keys, login profiles or MFA devices"
 }
 
@@ -59,6 +61,7 @@ variable "path" {
 }
 
 variable "enabled" {
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Set to false to prevent the module from creating any resources"
 }


### PR DESCRIPTION
The two variables `var.ssm_actions` and `var.ssm_resources` are lists. In this modules' `main.tf` they where used as lists. 

This PR fixes this problem and updates the terraform syntax.